### PR TITLE
Improve workflow for copying+pasting from Shadertoy

### DIFF
--- a/bin/test_shader.fs
+++ b/bin/test_shader.fs
@@ -1,5 +1,7 @@
+uniform vec2 u_resolution;
+uniform vec2 u_mouse;
 uniform float u_elapsedTime;
-uniform vec2 u_resolution; 
+uniform int u_frames;
 
 float random (vec2 st) {
 	return fract(sin(dot(

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -33,7 +33,7 @@ App::App()
     if (!sf::Shader::isAvailable())
         throw std::runtime_error("Shaders are not available");
 
-    m_shaderSource.resize(5000);
+    m_shaderSource.resize(1000000);
 }
 
 App::~App() { ImGui::SFML::Shutdown(m_window); }
@@ -80,6 +80,7 @@ void App::run()
         m_window.draw(spr);
         ImGui::SFML::Render(m_window);
         m_window.display();
+        ++m_frames;
     }
 }
 
@@ -141,6 +142,7 @@ void App::updateUI(const sf::Time& dt)
     ImGui::Text("u_elapsedTime = Elapsed Time");
     ImGui::Text("u_resolution = Surface Resolution");
     ImGui::Text("u_mouse = Mouse Screen Position");
+    ImGui::Text("u_frames = Number of frames elapsed");
     ImGui::PopItemWidth();
     ImGui::End();
 
@@ -192,4 +194,5 @@ void App::setupShaderUniforms(const sf::Time& dt, const sf::Time& elapsed)
     mousePosition.y = renderTextureSize.y - mousePosition.y;
 
     m_shader.setUniform("u_mouse", mousePosition);
+    m_shader.setUniform("u_frames", m_frames);
 }

--- a/src/App.hpp
+++ b/src/App.hpp
@@ -20,4 +20,5 @@ private:
     std::string m_shaderSource;
     std::string m_errorString;
     bool m_didFailLastCompile { false };
+    sf::Int32 m_frames { 0 };
 };

--- a/src/App.hpp
+++ b/src/App.hpp
@@ -13,13 +13,37 @@ private:
     void logFPS(const sf::Time& dt);
     void updateUI(const sf::Time& dt);
     void setupShaderUniforms(const sf::Time& dt, const sf::Time& elapsed);
+    void loadAndCompileShader();
 
     sf::RenderWindow m_window;
     sf::RenderTexture m_renderTexture;
     sf::Shader m_shader;
     std::string m_shaderSource;
+    const std::string m_defaultUniformNames = R"str(
+            uniform vec2 u_resolution; 
+            uniform vec2 u_mouse;
+            uniform float u_elapsedTime;
+            uniform float u_deltaTime;
+            uniform int u_frames;
+            )str";
+
+    const std::string m_shaderToyUniformNames = R"str(
+            uniform vec2 iResolution; 
+            uniform vec2 iMouse;
+            uniform float iTime;
+            uniform float iTimeDelta;
+            uniform int iFrame;
+            )str";
+
+    const std::string m_shaderToyMainFunction = R"str(
+        void mainImage(out vec4, in vec2);
+        void main() {
+            mainImage(gl_FragColor, gl_FragCoord);
+        }
+    )str";
     std::string m_errorString;
     bool m_didFailLastCompile { false };
     bool m_failedToMakeRenderTexture { false };
+    bool m_useShaderToyNames { false };
     sf::Int32 m_frames { 0 };
 };

--- a/src/App.hpp
+++ b/src/App.hpp
@@ -20,5 +20,6 @@ private:
     std::string m_shaderSource;
     std::string m_errorString;
     bool m_didFailLastCompile { false };
+    bool m_failedToMakeRenderTexture { false };
     sf::Int32 m_frames { 0 };
 };


### PR DESCRIPTION
- Resolution resize
- iFrame/u_frames uniform (number of elapsed frames)
- Support uniform variable names from ShaderToy and append a `void main()` signature to the pasted source